### PR TITLE
Allow proxies usage.

### DIFF
--- a/neptune/__init__.py
+++ b/neptune/__init__.py
@@ -26,7 +26,7 @@ project = None
 __lock = threading.RLock()
 
 
-def init(project_qualified_name=None, api_token=None):
+def init(project_qualified_name=None, api_token=None, proxies={}):
     if project_qualified_name is None:
         project_qualified_name = os.getenv(envs.PROJECT_ENV_NAME)
 
@@ -34,7 +34,7 @@ def init(project_qualified_name=None, api_token=None):
     with __lock:
         global session, project
 
-        session = Session(api_token=api_token)
+        session = Session(api_token=api_token, proxies=proxies)
 
         if project_qualified_name is None:
             raise MissingProjectQualifiedName()

--- a/neptune/__init__.py
+++ b/neptune/__init__.py
@@ -26,7 +26,7 @@ project = None
 __lock = threading.RLock()
 
 
-def init(project_qualified_name=None, api_token=None, proxies={}):
+def init(project_qualified_name=None, api_token=None, proxies=None):
     if project_qualified_name is None:
         project_qualified_name = os.getenv(envs.PROJECT_ENV_NAME)
 

--- a/neptune/client.py
+++ b/neptune/client.py
@@ -74,16 +74,15 @@ def with_api_exceptions_handler(func):
 class Client(object):
 
     @with_api_exceptions_handler
-    def __init__(self, api_address, api_token):
+    def __init__(self, api_address, api_token, proxies={}):
         self.api_address = api_address
         self.api_token = api_token
-
         ssl_verify = True
         if os.getenv("NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE"):
             urllib3.disable_warnings()
             ssl_verify = False
 
-        self._http_client = RequestsClient(ssl_verify=ssl_verify)
+        self._http_client = RequestsClient(ssl_verify=ssl_verify, proxies=proxies)
 
         self.backend_swagger_client = SwaggerClient.from_url(
             '{}/api/backend/swagger.json'.format(self.api_address),

--- a/neptune/client.py
+++ b/neptune/client.py
@@ -84,7 +84,7 @@ class Client(object):
             ssl_verify = False
 
         self._http_client = RequestsClient(ssl_verify=ssl_verify)
-        self._http_client.session.proxies.update(proxies)
+        self.update_proxies()
 
         self.backend_swagger_client = SwaggerClient.from_url(
             '{}/api/backend/swagger.json'.format(self.api_address),
@@ -110,6 +110,15 @@ class Client(object):
             self.backend_swagger_client.api.exchangeApiToken(X_Neptune_Api_Token=api_token).response().result
         )
         self._http_client.authenticator = self.authenticator
+
+    @with_api_exceptions_handler
+    def update_proxies(self):
+        try:
+            self._http_client.session.proxies.update(self.proxies)
+        except:
+            # TODO: change error type and info
+            raise ValueError(f"Error when using this proxies {proxies}")
+
 
     @with_api_exceptions_handler
     def get_project(self, project_qualified_name):

--- a/neptune/client.py
+++ b/neptune/client.py
@@ -74,7 +74,7 @@ def with_api_exceptions_handler(func):
 class Client(object):
 
     @with_api_exceptions_handler
-    def __init__(self, api_address, api_token, proxies={}):
+    def __init__(self, api_address, api_token, proxies=None):
         self.api_address = api_address
         self.api_token = api_token
         self.proxies = proxies
@@ -84,7 +84,8 @@ class Client(object):
             ssl_verify = False
 
         self._http_client = RequestsClient(ssl_verify=ssl_verify)
-        self.update_proxies()
+        if proxies is not None:
+            self._update_proxies()
 
         self.backend_swagger_client = SwaggerClient.from_url(
             '{}/api/backend/swagger.json'.format(self.api_address),
@@ -110,15 +111,6 @@ class Client(object):
             self.backend_swagger_client.api.exchangeApiToken(X_Neptune_Api_Token=api_token).response().result
         )
         self._http_client.authenticator = self.authenticator
-
-    @with_api_exceptions_handler
-    def update_proxies(self):
-        try:
-            self._http_client.session.proxies.update(self.proxies)
-        except:
-            # TODO: change error type and info
-            raise ValueError("Error when using proxies {}".format(self.proxies))
-
 
     @with_api_exceptions_handler
     def get_project(self, project_qualified_name):
@@ -675,6 +667,14 @@ class Client(object):
         )
 
         return session.send(session.prepare_request(request))
+
+
+    def _update_proxies(self):
+        try:
+            self._http_client.session.proxies.update(self.proxies)
+        except:
+            # TODO: change error type and info
+            raise ValueError("Error when using proxies {}".format(self.proxies))
 
 
 uuid_format = SwaggerFormat(

--- a/neptune/client.py
+++ b/neptune/client.py
@@ -77,12 +77,14 @@ class Client(object):
     def __init__(self, api_address, api_token, proxies={}):
         self.api_address = api_address
         self.api_token = api_token
+        self.proxies = proxies
         ssl_verify = True
         if os.getenv("NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE"):
             urllib3.disable_warnings()
             ssl_verify = False
 
-        self._http_client = RequestsClient(ssl_verify=ssl_verify, proxies=proxies)
+        self._http_client = RequestsClient(ssl_verify=ssl_verify)
+        self._http_client.session.proxies.update(proxies)
 
         self.backend_swagger_client = SwaggerClient.from_url(
             '{}/api/backend/swagger.json'.format(self.api_address),

--- a/neptune/client.py
+++ b/neptune/client.py
@@ -84,7 +84,7 @@ class Client(object):
             ssl_verify = False
 
         self._http_client = RequestsClient(ssl_verify=ssl_verify)
-        if proxies is not None:
+        if self.proxies is not None:
             self._update_proxies()
 
         self.backend_swagger_client = SwaggerClient.from_url(

--- a/neptune/client.py
+++ b/neptune/client.py
@@ -117,7 +117,7 @@ class Client(object):
             self._http_client.session.proxies.update(self.proxies)
         except:
             # TODO: change error type and info
-            raise ValueError(f"Error when using this proxies {proxies}")
+            raise ValueError("Error when using proxies {}".format(self.proxies))
 
 
     @with_api_exceptions_handler

--- a/neptune/sessions.py
+++ b/neptune/sessions.py
@@ -50,11 +50,13 @@ class Session(object):
         >>> session = Session()
     """
 
-    def __init__(self, api_token=None):
+    def __init__(self, api_token=None, proxies={}):
         credentials = Credentials(api_token)
 
         self.credentials = credentials
-        self._client = Client(self.credentials.api_address, self.credentials.api_token)
+        self.proxies = proxies
+
+        self._client = Client(self.credentials.api_address, self.credentials.api_token, proxies)
 
     def get_project(self, project_qualified_name):
         """

--- a/neptune/sessions.py
+++ b/neptune/sessions.py
@@ -50,7 +50,7 @@ class Session(object):
         >>> session = Session()
     """
 
-    def __init__(self, api_token=None, proxies={}):
+    def __init__(self, api_token=None, proxies=None):
         credentials = Credentials(api_token)
 
         self.credentials = credentials


### PR DESCRIPTION
Allow to use proxies. Experimented pass.

Simple example to verify:

1. Create local dynamic port forwarding:
```
ssh -D 9999 user@localhost
```
2. Run the following:
```python
if __name__ == '__main__':
    proxies = {"http": "socks5h://127.0.0.1:9999", 'https': 'socks5h://127.0.0.1:9999'}
    neptune.init(project_qualified_name='namespace/project', proxies=proxies)
    neptune.create_experiment()
    neptune.send_metric('Test', 0)


```

