### PR TITLE
Catch more exceptions in hardware/channel sending threads

### DIFF
--- a/neptune/internal/channels/channels_values_sender.py
+++ b/neptune/internal/channels/channels_values_sender.py
@@ -21,7 +21,7 @@ from itertools import groupby
 
 from future.moves import queue
 
-from neptune.api_exceptions import NeptuneApiException
+from neptune.exceptions import NeptuneException
 from neptune.internal.channels.channels import ChannelIdWithValues, ChannelNameWithTypeAndNamespace, ChannelValue,\
     ChannelType, ChannelNamespace
 from neptune.internal.threads.neptune_thread import NeptuneThread
@@ -111,7 +111,7 @@ class ChannelsValuesSendingThread(NeptuneThread):
             try:
                 self._send_values(self._values_batch)
                 self._values_batch = []
-            except (NeptuneApiException, IOError) as e:
+            except (NeptuneException, IOError) as e:
                 _logger.warning('Failed to send channel value: %s', e)
         self._sleep_time = self._SLEEP_TIME - (time.time() - send_start)
 
@@ -154,5 +154,5 @@ class ChannelsValuesSendingThread(NeptuneThread):
         try:
             # pylint:disable=protected-access
             self._experiment._send_channels_values(channels_with_values)
-        except (NeptuneApiException, IOError) as e:
+        except (NeptuneException, IOError) as e:
             _logger.warning('Failed to send channel value: %s', e)

--- a/neptune/internal/threads/hardware_metric_reporting_thread.py
+++ b/neptune/internal/threads/hardware_metric_reporting_thread.py
@@ -18,6 +18,7 @@ import time
 
 from bravado.exception import HTTPError
 
+from neptune.exceptions import NeptuneException
 from neptune.internal.threads.neptune_thread import NeptuneThread
 
 _logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ class HardwareMetricReportingThread(NeptuneThread):
 
                 try:
                     self.__metric_service.report_and_send(timestamp=time.time())
-                except HTTPError as e:
+                except (NeptuneException, HTTPError) as e:
                     _logger.debug('Unexpected HTTP error in hardware metric reporting thread: %s', e)
 
                 reporting_duration = time.time() - before


### PR DESCRIPTION
We've been catching HTTP exceptions in the hardware monitoring thread, while our HttpClient wrapped some of those exceptions in Neptune exceptions, which resulted in the thread dying prematurely.