### PR TITLE
Fix text logging to restored experiment

### DIFF
--- a/neptune/backend.py
+++ b/neptune/backend.py
@@ -26,6 +26,10 @@ class Backend(object):
     def api_address(self):
         pass
 
+    @abstractproperty
+    def display_address(self):
+        pass
+
     @abstractmethod
     def get_project(self, project_qualified_name):
         pass

--- a/neptune/exceptions.py
+++ b/neptune/exceptions.py
@@ -104,3 +104,13 @@ class InvalidNeptuneBackend(NeptuneException):
             'Use this environment variable to modify neptune-client behaviour at runtime, '
             'e.g. using {}=offline allows you to run your code without logging anything to Neptune'
             .format(envs.BACKEND, provided_backend_name, envs.BACKEND))
+
+class DeprecatedApiToken(NeptuneException):
+    def __init__(self, app_url):
+        super(DeprecatedApiToken, self).__init__(
+            "Your API token is deprecated. Please visit {} to get a new one.".format(app_url))
+
+class CannotResolveHostname(NeptuneException):
+    def __init__(self, host):
+        super(CannotResolveHostname, self).__init__(
+            "Cannot resolve hostname {}. Please contact Neptune support.".format(host))

--- a/neptune/experiments.py
+++ b/neptune/experiments.py
@@ -150,7 +150,7 @@ class Experiment(object):
     def get_system_properties(self):
         """Retrieve experiment properties.
 
-        | Experiment properties are for example: `owner`, `time of creation`, `time of completion`, `hostname`.
+        | Experiment properties are for example: `owner`, `created`, `name`, `hostname`.
         | List of experiment properties may change over time.
 
         Returns:
@@ -171,9 +171,13 @@ class Experiment(object):
             'finished': experiment.timeOfCompletion,
             'running_time': experiment.runningTime,
             'owner': experiment.owner,
-            'size': experiment.storageSize,
+            'storage_size': experiment.storageSize,
+            'channels_size': experiment.channelsSize,
+            'size': experiment.storageSize + experiment.channelsSize,
             'tags': experiment.tags,
-            'notes': experiment.description
+            'notes': experiment.description,
+            'description': experiment.description,
+            'hostname': experiment.hostname
         }
 
     def get_tags(self):

--- a/neptune/internal/backends/client_config.py
+++ b/neptune/internal/backends/client_config.py
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2019, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class ClientConfig(object):
+
+    def __init__(self, api_url, display_url):
+        self._api_url = api_url
+        self._display_url = display_url
+
+    @property
+    def api_url(self):
+        return self._api_url
+
+    @property
+    def display_url(self):
+        return self._display_url

--- a/neptune/internal/backends/credentials.py
+++ b/neptune/internal/backends/credentials.py
@@ -75,15 +75,21 @@ class Credentials(object):
         if self.api_token is None:
             raise MissingApiToken()
 
-        self._api_address = self._api_token_to_dict(self.api_token)['api_address']
+        token_dict = self._api_token_to_dict(self.api_token)
+        self._token_origin_address = token_dict['api_address']
+        self._api_url = token_dict['api_url'] if 'api_url' in token_dict else None
 
     @property
     def api_token(self):
         return self._api_token
 
     @property
-    def api_address(self):
-        return self._api_address
+    def token_origin_address(self):
+        return self._token_origin_address
+
+    @property
+    def api_url_opt(self):
+        return self._api_url
 
     @staticmethod
     def _api_token_to_dict(api_token):

--- a/neptune/internal/backends/offline_backend.py
+++ b/neptune/internal/backends/offline_backend.py
@@ -31,6 +31,10 @@ class OfflineBackend(Backend):
     def api_address(self):
         return 'OFFLINE'
 
+    @property
+    def display_address(self):
+        return 'OFFLINE'
+
     def get_project(self, project_qualified_name):
         return NoopObject()
 

--- a/neptune/internal/streams/channel_writer.py
+++ b/neptune/internal/streams/channel_writer.py
@@ -16,7 +16,7 @@
 
 from __future__ import unicode_literals
 
-from datetime import datetime, timezone
+from datetime import datetime
 import re
 
 from neptune.internal.channels.channels import ChannelNamespace, ChannelValue, ChannelType
@@ -40,7 +40,7 @@ class ChannelWriter(object):
         lines = self.__SPLIT_PATTERN.split(self._data)
         for line in lines[:-1]:
             value = ChannelValue(
-                x=(datetime.now(tz=timezone.utc) - self._time_started).total_seconds() * 1000,
+                x=(datetime.now(tz=self._time_started.tzinfo) - self._time_started).total_seconds() * 1000,
                 y=dict(text_value=str(line)),
                 ts=None
             )

--- a/neptune/internal/streams/channel_writer.py
+++ b/neptune/internal/streams/channel_writer.py
@@ -16,8 +16,8 @@
 
 from __future__ import unicode_literals
 
+from datetime import datetime, timezone
 import re
-import time
 
 from neptune.internal.channels.channels import ChannelNamespace, ChannelValue, ChannelType
 
@@ -26,7 +26,7 @@ class ChannelWriter(object):
     __SPLIT_PATTERN = re.compile(r'[\n\r]{1,2}')
 
     def __init__(self, experiment, channel_name, channel_namespace=ChannelNamespace.USER):
-        self.time_started_ms = time.time() * 1000
+        self._time_started = experiment.get_system_properties()['created']
         self._experiment = experiment
         self._channel_name = channel_name
         self._channel_namespace = channel_namespace
@@ -40,7 +40,7 @@ class ChannelWriter(object):
         lines = self.__SPLIT_PATTERN.split(self._data)
         for line in lines[:-1]:
             value = ChannelValue(
-                x=time.time() * 1000 - self.time_started_ms,
+                x=(datetime.now(tz=timezone.utc) - self._time_started).total_seconds() * 1000,
                 y=dict(text_value=str(line)),
                 ts=None
             )

--- a/neptune/projects.py
+++ b/neptune/projects.py
@@ -468,7 +468,7 @@ class Project(object):
 
     def _get_experiment_link(self, experiment):
         return "{base_url}/{namespace}/{project}/e/{exp_id}".format(
-            base_url=self._backend.api_address,
+            base_url=self._backend.display_address,
             namespace=self.namespace,
             project=self.name,
             exp_id=experiment.id


### PR DESCRIPTION
Now when the experiment is restored from neptune server, you can log text
(stdout, stderr, logger) without the fear that the x values will be
the same as the old ones and will be discarded. (see the rationale:
https://spectrum.chat/neptune-community/general/continuing-an-interrupted-experiment~e9fff5f8-c322-48fc-a84f-2ece82e5c630)

Fixes #105